### PR TITLE
Update comments + stories to reflect pill default for `Button`

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -63,11 +63,12 @@ Icon.args = {
   color: "secondary",
   size: "lg",
   uniform: true,
+  pill: false,
   variant: "ghost",
 }
 
 Icon.parameters = {
-  controls: { include: ["size", "gutterSize", "iconSize", "uniform", "variant"] },
+  controls: { include: ["size", "gutterSize", "iconSize", "uniform", "pill", "variant"] },
 }
 
 Icon.argTypes = {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -32,7 +32,7 @@ type CommonProps = {
   variant?: Variants<"solid" | "soft" | "outline" | "ghost">
   /**
    * Determines if the button should be a fully rounded pill shape
-   * @default false
+   * @default true
    */
   pill?: boolean
   /**


### PR DESCRIPTION
From #10

## Issues
* `Button` with `Icon` story usage talks about square buttons but did not provide `pill` controls
* JSDoc for `Button` `pill` mentioned `pill` is default `false`

## Changes
* Updates story for `Button` + `Icon` to have controls for `pill` set to `false`
* Updates JSDoc

