### PR TITLE
[codex] pass input autocomplete

### DIFF
--- a/src/components/Input/Input.mdx
+++ b/src/components/Input/Input.mdx
@@ -91,7 +91,7 @@ Pass `autoSelect` to select all text in the input &ndash; useful when pairing wi
 
 By default, autofill extensions are prevented by `Input`. For the occasions where you want browser extensions to be present, pass `allowAutofillExtensions` to remove the disabling.
 
-When `name` is passed, or `type` is set to `"password"`, this value will default to `true`.
+When `name` is passed, `autoComplete` is passed, or `type` is set to `"password"`, this value will default to `true`.
 
 <Canvas of={InputStories.AutofillExtensions} />
 <div className="canvas-controls-only">

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -174,11 +174,12 @@ export const AutofillExtensions = (args: InputProps) => (
 )
 AutofillExtensions.args = {
   allowAutofillExtensions: true,
+  autoComplete: "email",
   name: "email",
 }
 
 AutofillExtensions.parameters = {
-  controls: { include: ["allowAutofillExtensions"] },
+  controls: { include: ["allowAutofillExtensions", "autoComplete"] },
 }
 
 export const WithButton = (args: InputProps) => (

--- a/src/components/Input/Input.test.tsx
+++ b/src/components/Input/Input.test.tsx
@@ -1,0 +1,34 @@
+import { render } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { Input } from "./"
+
+describe("Input", () => {
+  it("passes autoComplete to the native input", () => {
+    const { getByPlaceholderText } = render(
+      <Input autoComplete="email" placeholder="Email address" />,
+    )
+
+    expect(getByPlaceholderText("Email address")).toHaveAttribute("autocomplete", "email")
+  })
+
+  it("allows autofill extensions by default when autoComplete is provided", () => {
+    const { getByPlaceholderText } = render(
+      <Input autoComplete="email" placeholder="Email address" />,
+    )
+
+    const input = getByPlaceholderText("Email address")
+    expect(input).not.toHaveAttribute("data-lpignore")
+    expect(input).not.toHaveAttribute("data-1p-ignore")
+  })
+
+  it("allows autofill extensions to be explicitly disabled when autoComplete is provided", () => {
+    const { getByPlaceholderText } = render(
+      <Input allowAutofillExtensions={false} autoComplete="email" placeholder="Email address" />,
+    )
+
+    const input = getByPlaceholderText("Email address")
+    expect(input).toHaveAttribute("autocomplete", "email")
+    expect(input).toHaveAttribute("data-lpignore", "true")
+    expect(input).toHaveAttribute("data-1p-ignore", "true")
+  })
+})

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -42,7 +42,7 @@ export type InputProps = {
   invalid?: boolean
   /**
    * Allow autofill extensions to appear in the input
-   * @default false
+   * @default true when type="password", name is present, or autoComplete is provided
    */
   allowAutofillExtensions?: boolean
   /**
@@ -88,8 +88,10 @@ export const Input = (props: InputProps) => {
     disabled = false,
     readOnly = false,
     invalid = false,
-    // Default to `true` when type="password" or presence of `name`
-    allowAutofillExtensions = type === "password" || !!name,
+    // Default to `true` when the field declares autofill semantics.
+    allowAutofillExtensions = type === "password" ||
+      !!name ||
+      (!!autoComplete && autoComplete !== "off"),
     onFocus,
     onBlur,
     onAnimationStart,
@@ -195,6 +197,7 @@ export const Input = (props: InputProps) => {
         className={s.Input}
         type={type}
         name={name}
+        autoComplete={autoComplete}
         readOnly={readOnly}
         disabled={disabled}
         onFocus={(evt) => {


### PR DESCRIPTION
## Summary

This PR fixes `Input` so autocomplete semantics supplied by consumers reach the underlying native `<input>` element. Apps can now pass values such as `autoComplete="email"` and get the expected browser autofill and password-manager behavior.

The issue showed up in app forms where users had to manually type details that Chrome or 1Password would normally offer to fill. That made forms built with the open source UI component feel worse than the same form built with a plain browser input.

## Root cause

`Input` accepted all native input attributes through `React.InputHTMLAttributes`, and it destructured `autoComplete` from props. Because `autoComplete` was pulled out before `...restProps`, it no longer flowed through with the rest of the native attributes. The component then never re-applied it to the rendered `<input>`, so consumers could pass the prop without a TypeScript error while the DOM silently omitted `autocomplete`.

The component also intentionally suppresses autofill extensions for generic text fields by default. That behavior still makes sense for arbitrary UI inputs, but an explicit autocomplete semantic means the field is declaring autofill intent. This PR treats that as an opt-in signal, unless the consumer passes `autoComplete="off"` or explicitly sets `allowAutofillExtensions={false}`.

## Changes

- Pass `autoComplete` through to the native `<input>`.
- Default `allowAutofillExtensions` to true when a meaningful `autoComplete` value is provided.
- Add regression tests covering DOM attribute forwarding, the new default autofill-extension behavior, and explicit opt-out behavior.
- Update the Storybook example and MDX docs so the autofill guidance mentions `autoComplete`.

## Validation

- `npm run format:fix`
- `npm run lint`
- `npm run types`
- `npm run test`
