### PR TITLE
[codex] release 0.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openai/apps-sdk-ui",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openai/apps-sdk-ui",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/apps-sdk-ui",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Design system for building apps for ChatGPT with Apps SDK",
   "license": "MIT",
   "homepage": "https://github.com/openai/apps-sdk-ui#readme",


### PR DESCRIPTION
## Summary

Bumps `@openai/apps-sdk-ui` from `0.2.1` to `0.2.2` so we can publish the merged Input autocomplete fix as a new package version.

## Context

PR #42 fixed `Input` so native `autoComplete` values are passed through to the underlying `<input>` and can opt the field into normal browser/password-manager autofill behavior. Tyler noted that this repo does not currently have release CI, so the package version needs to be bumped before creating a GitHub release and publishing manually.

## Validation

- `npm run format:fix`
