### PR TITLE
[codex] add npm trusted publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,50 @@
+name: Publish package
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Package version to publish, without a leading v"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22.14.0"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install npm 11
+        run: npm install --global npm@11
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify release version
+        env:
+          EXPECTED_VERSION: ${{ github.event.release.tag_name || inputs.version }}
+        run: |
+          package_version="$(node -p "require('./package.json').version")"
+          expected_version="${EXPECTED_VERSION#v}"
+
+          if [ "$package_version" != "$expected_version" ]; then
+            echo "Package version $package_version does not match release version $expected_version"
+            exit 1
+          fi
+
+      - name: Publish to npm
+        run: npm publish --access public


### PR DESCRIPTION
## Summary
- add a GitHub Actions publish workflow for npm trusted publishing
- publish on GitHub Release publication, with manual dispatch support for backfilling the current 0.2.2 release
- verify the release/manual version matches package.json before publishing

## npm Trusted Publisher settings
- Organization or user: `openai`
- Repository: `apps-sdk-ui`
- Workflow filename: `publish.yml`
- Environment name: leave blank

After this merges and npm is configured, run the workflow manually with version `0.2.2` to publish the already-created release. Future GitHub releases should publish automatically.

## Testing
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/publish.yml'); puts 'yaml ok'"`\n- `npx prettier --check .github/workflows/publish.yml`\n- `npm run format:fix`\n- `npm run lint`\n- `npm run types`\n- `npm run test`\n- `npm publish --dry-run --access public`